### PR TITLE
Revised init command

### DIFF
--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -12,7 +12,7 @@ set -e
 # Console colors
 red='\033[0;31m'
 green='\033[0;32m'
-green_bg='\033[1;97;42m'
+green_bg='\033[42m'
 yellow='\033[1;33m'
 NC='\033[0m'
 

--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -1,24 +1,18 @@
 #!/usr/bin/env bash
 
-## Run blt setup commands to prepare your local site for
-## development.
+## Initialize stack and site (full reset)
 ##
 ## Usage: fin init
 
 # Abort if anything fails
 set -e
-#-------------------------- Settings --------------------------------
-
-DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-
-#-------------------------- END: Settings --------------------------------
 
 #-------------------------- Helper functions --------------------------------
 
 # Console colors
 red='\033[0;31m'
 green='\033[0;32m'
-green_bg='\033[42m'
+green_bg='\033[1;97;42m'
 yellow='\033[1;33m'
 NC='\033[0m'
 
@@ -27,23 +21,15 @@ echo-green () { echo -e "${green}$1${NC}"; }
 echo-green-bg () { echo -e "${green_bg}$1${NC}"; }
 echo-yellow () { echo -e "${yellow}$1${NC}"; }
 
-#-------------------------- END: Helper Functions --------------------------------
-
 #-------------------------- Execution --------------------------------
 
-# Initialize stack
-fin reset -f
+# Stack initialization
+echo -e "${green_bg} Step 1 ${NC}${green} Initializing stack...${NC}"
+fin project reset -f
 
-# Install project requirements
-fin exec composer clear-cache --no-interaction
-fin exec COMPOSER_PROCESS_TIMEOUT=2000
-fin exec COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction
+# Site initialization
+echo -e "${green_bg} Step 2 ${NC}${green} Initializing site...${NC}"
+# This runs inside cli using http://docs.docksal.io/en/v1.4.0/fin/custom-commands/#executing-commands-inside-cli
+fin init-site
 
-# Set up blt
-cd $DOCROOT_PATH
-fin blt setup --no-interaction
-
-echo
-echo -en "${green_bg} DONE! ${NC}"
-echo
-echo -e "Open ${yellow}http://${VIRTUAL_HOST}${NC} in your browser to verify the setup."
+echo -e "${green_bg} DONE! ${NC}${green} Completed all initialization steps.${NC}"

--- a/.docksal/commands/init-site
+++ b/.docksal/commands/init-site
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+#: exec_target = cli
+
+## Initialize/reinstall site
+##
+## Usage: fin init-site
+
+# Abort if anything fails
+set -e
+
+#-------------------------- Settings --------------------------------
+
+# PROJECT_ROOT and DOCROOT are set as env variables in cli
+DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
+
+#-------------------------- Helper functions --------------------------------
+
+# Console colors
+red='\033[0;31m'
+green='\033[0;32m'
+green_bg='\033[1;97;42m'
+yellow='\033[1;33m'
+NC='\033[0m'
+
+echo-red () { echo -e "${red}$1${NC}"; }
+echo-green () { echo -e "${green}$1${NC}"; }
+echo-green-bg () { echo -e "${green_bg}$1${NC}"; }
+echo-yellow () { echo -e "${yellow}$1${NC}"; }
+
+#-------------------------- Functions --------------------------------
+
+composer_install ()
+{
+	cd "$PROJECT_ROOT"
+	echo-green "Installing dependencies..."
+	export COMPOSER_PROCESS_TIMEOUT=2000
+	export COMPOSER_MEMORY_LIMIT=-1
+	composer clear-cache --no-interaction
+	composer install --no-interaction
+}
+
+# blt setup
+blt_setup ()
+{
+	cd "$DOCROOT_PATH"
+
+	# Allow exiting to configure project before install.
+	echo
+	echo-yellow "Going to run BLT setup..."
+	echo -e "Press ${yellow}Ctrl+C${NC} if you want to make changes to ${yellow}bly.yml${NC}."
+	echo -e "After configuring your ${yellow}bly.yml${NC}, run ${yellow}fin blt setup${NC} to complete your setup."
+	echo
+	sleep 30
+
+	echo-green "Running BLT setup..."
+	../vendor/bin/blt setup --no-interaction
+}
+
+#-------------------------- Execution --------------------------------
+
+# Project initialization steps
+composer_install
+blt_setup
+
+echo
+echo -e "Open ${yellow}http://${VIRTUAL_HOST}${NC} in your browser to verify the setup."
+echo-yellow "Look for admin login credentials in the output above."

--- a/.docksal/commands/init-site
+++ b/.docksal/commands/init-site
@@ -48,8 +48,8 @@ blt_setup ()
 	# Allow exiting to configure project before install.
 	echo
 	echo-yellow "Going to run BLT setup..."
-	echo -e "Press ${yellow}Ctrl+C${NC} if you want to make changes to ${yellow}bly.yml${NC}."
-	echo -e "After configuring your ${yellow}bly.yml${NC}, run ${yellow}fin blt setup${NC} to complete your setup."
+	echo -e "Press ${yellow}Ctrl+C${NC} if you want to make changes to ${yellow}blt.yml${NC}."
+	echo -e "After configuring your ${yellow}blt.yml${NC}, run ${yellow}fin blt setup${NC} to complete your setup."
 	echo
 	sleep 30
 


### PR DESCRIPTION
- Split into `init` and `init-site`
- Allow exiting to configure project before running "blt setup" (scripts proceeds by default after 30s)
  - Resolves #11
  - Closes #12
  - Closes #14
  - Closes #16

<img width="541" alt="Screen Shot 2022-05-09 at 18 12 27" src="https://user-images.githubusercontent.com/1205005/167523206-7552ba70-f853-4962-884c-08288808f624.png">

The reason for "Yes, unless you cancel" approach here is to ensure `fin init` will always run and complete with default assumption and without any extra arguments or user prompts.